### PR TITLE
Correctly close the Language Chooser Macro

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -156,4 +156,4 @@ outputs:
 ```
 {{% /choosable %}}
 
-{{< /chooser >}
+{{< /chooser >}}


### PR DESCRIPTION
I have done this [manually](https://github.com/pulumi/registry/pull/6501/commits/772c600f624d6f0668cd9e6bcb187f1a3be2aba0) in the Pulumi registry, to avoid needing another release. Future releases will fail to publish to the Pulumi registry without this change.