### PR TITLE
Dont update or create when in preview phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,12 @@
 **/.vs
 **/.idea
 **/.ionide
+**/__debug*
 .pulumi
 Pulumi.*.yaml
 yarn.lock
 ci-scripts
 /nuget/
 provider/**/schema-embed.json
+.direnv/
+.vscode/

--- a/provider/cmd/pulumi-resource-kafkaconnect/main.go
+++ b/provider/cmd/pulumi-resource-kafkaconnect/main.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	p "github.com/pulumi/pulumi-go-provider"
 
@@ -24,5 +26,9 @@ import (
 
 // Serve the provider against Pulumi's Provider protocol.
 func main() {
-	p.RunProvider(context.Background(), kafkaconnect.Name, kafkaconnect.Version, kafkaconnect.Provider())
+	err := p.RunProvider(context.Background(), kafkaconnect.Name, kafkaconnect.Version, kafkaconnect.Provider())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
 }

--- a/provider/pkg/kafkaconnect/connector/connectorResource.go
+++ b/provider/pkg/kafkaconnect/connector/connectorResource.go
@@ -33,6 +33,9 @@ func getClient(ctx context.Context) connectors.HighLevelClient {
 }
 
 func (*Connector) Create(ctx context.Context, req infer.CreateRequest[ConnectorArgs]) (infer.CreateResponse[ConnectorState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[ConnectorState]{ID: req.Name, Output: ConnectorState{Config: req.Inputs.Config}}, nil
+	}
 	client := getClient(ctx)
 
 	resp, err := client.CreateConnector(connectors.CreateConnectorRequest{
@@ -56,6 +59,9 @@ func (*Connector) Create(ctx context.Context, req infer.CreateRequest[ConnectorA
 }
 
 func (c *Connector) Update(ctx context.Context, req infer.UpdateRequest[ConnectorArgs, ConnectorState]) (infer.UpdateResponse[ConnectorState], error) {
+	if req.DryRun {
+		return infer.UpdateResponse[ConnectorState]{Output: ConnectorState{Config: req.Inputs.Config}}, nil
+	}
 	client := getClient(ctx)
 	resp, err := client.UpdateConnector(connectors.CreateConnectorRequest{
 		ConnectorRequest: connectors.ConnectorRequest{


### PR DESCRIPTION
This was a pretty bad bug where connectors could be created in preview phase.
Happened to us a few times.
Its not much written about here https://www.pulumi.com/docs/iac/extending-pulumi/build-a-provider/
But it should return without any side-effects when DryRun is true